### PR TITLE
Added flag to PointMarker Styler to optionally clamp marker to terrain.

### DIFF
--- a/Toolkit/src/osh/ui/styler/osh-UI-StylerPointMarker.js
+++ b/Toolkit/src/osh/ui/styler/osh-UI-StylerPointMarker.js
@@ -67,8 +67,13 @@ OSH.UI.Styler.PointMarker = OSH.UI.Styler.extend({
 		this.iconAnchor = [16,16];
 		this.label = null;
 		this.color = "#000000";
-		
+		this.defaultToTerrainElevation = false;
+
 		this.options = {};
+
+		if(typeof(properties.defaultToTerrainElevation) != "undefined") {
+			this.defaultToTerrainElevation = properties.defaultToTerrainElevation;
+		}
 		
 		if(typeof(properties.location) != "undefined"){
 			this.location = properties.location;

--- a/Toolkit/src/osh/ui/view/map/osh-UI-CesiumView.js
+++ b/Toolkit/src/osh/ui/view/map/osh-UI-CesiumView.js
@@ -105,6 +105,7 @@ OSH.UI.CesiumView = OSH.UI.View.extend({
 			color : styler.color,
 			icon : styler.icon,
 			timeStamp: timeStamp,
+            defaultToTerrainElevation: styler.defaultToTerrainElevation,
 			selected:((typeof(options.selected) !== "undefined")? options.selected : false)
 		});
 	},
@@ -390,12 +391,13 @@ OSH.UI.CesiumView = OSH.UI.View.extend({
         var alt = properties.alt;
         var orient = properties.orientation;
         var imgIcon = properties.icon;
-        
+		var defaultToTerrainElevation = properties.defaultToTerrainElevation;
+
         if (!isNaN(lon) && !isNaN(lat)) {
         	var marker =  this.markers[id];
         	
         	// get ground altitude if non specified
-        	if (typeof(alt) === "undefined" || isNaN(alt)) {
+        	if (typeof(alt) === "undefined" || isNaN(alt) || defaultToTerrainElevation === true) {
 	    		alt = this.getAltitude(lat, lon);
 	    		if (alt > 1)
 	    			alt += 0.3;


### PR DESCRIPTION
This modification applies to CesiumViewer for 3D viewing to ensure that for ground based elements there is an option to ignore altitude if provided by styler and use terrain at current latitude and longitude.