### PR TITLE
[SWE API] Adjust for latest server side changes #626

### DIFF
--- a/demos/sweapi/src/App.vue
+++ b/demos/sweapi/src/App.vue
@@ -257,7 +257,7 @@ export default {
         node = this.nodes[id];
         this.nodeId = node.id;
         this.controlStreamCommand = node.control;
-        this.panels.controlStatusLive = true;
+        this.panels.commandStatusLive = true;
       } else if (id.startsWith('control-search-command')) {
         node = this.nodes[id];
         this.nodeId = node.id;
@@ -269,6 +269,7 @@ export default {
         node = this.nodes[id];
         this.nodeId = node.id;
         this.controlStreamStatus = node.control;
+        this.panels.controlStatusLive = true;
       } else if (id.startsWith('control-search-status')) {
         node = this.nodes[id];
         this.nodeId = node.id;

--- a/demos/tasking/src/App.vue
+++ b/demos/tasking/src/App.vue
@@ -60,7 +60,6 @@ import TimeLine from "./components/TimeLine.vue";
 import SweApiFetchJson from "osh-js/core/datasource/sweapi/SweApiFetchJson";
 import Systems from "osh-js/core/sweapi/system/Systems";
 import Control from "../../../source/core/sweapi/control/Control";
-import {EventType} from "../../../source/core/event/EventType";
 
 //https://ogct17.georobotix.io:8443/sensorhub/sos?service=SOS&version=2.0&request=GetCapabilities
 export default {
@@ -100,10 +99,9 @@ export default {
 
     this.control = new Control({
       id: cmdStreamId,
-      system: {
-        id: systemId
-      }
-    }, {
+      'system@id': systemId
+    },
+    {
       endpointUrl: 'ogct17.georobotix.io:8443/sensorhub/api',
       mqttEndpointUrl: 'ogct17.georobotix.io:8483',
       streamProtocol: 'mqtt',

--- a/demos/tasking/src/components/InfoPanel.vue
+++ b/demos/tasking/src/components/InfoPanel.vue
@@ -88,7 +88,7 @@ export default {
         const status = JSON.parse(statusStr);
         this.textStatus = status;
 
-        const command = await this.control.getCommandById(status.command);
+        const command = await this.control.getCommandById(status['command@id']);
 
         this.commands.set(command.properties.id, {
           type : Object.keys(command.properties.params)[0],

--- a/demos/tasking/src/components/Map.vue
+++ b/demos/tasking/src/components/Map.vue
@@ -53,7 +53,7 @@ export default {
       const waypoints = new PointMarkerLayer({
         dataSourceId: this.controlDataSource.id,
         getLocation: async (rec) => {
-          let command = await this.getCommand(rec.command);
+          let command = await this.getCommand(rec['command@id']);
           let type = Object.keys(command.properties.params)[0];
           const pos = command.properties.params[type].position;
           return {
@@ -63,7 +63,7 @@ export default {
           }
         },
         getMarkerId: async (rec) => {
-          let command = await this.getCommand(rec.command);
+          let command = await this.getCommand(rec['command@id']);
           return command.properties.id;
         },
         name: 'waypoint',

--- a/demos/tasking/src/components/TimeLine.vue
+++ b/demos/tasking/src/components/TimeLine.vue
@@ -58,7 +58,7 @@ export default {
       const status = message;
       this.textStatus = status;
 
-      const command = await this.control.getCommandById(status.command);
+      const command = await this.control.getCommandById(status['command@id']);
 
       await this.$store.dispatch('setCommand', {
         ...command.properties,

--- a/showcase/examples/tasking/tasking.js
+++ b/showcase/examples/tasking/tasking.js
@@ -88,7 +88,7 @@ async function startListening() {
         textCommandElt.innerHTML = "";
         const status = message;
         textStatusElt.innerHTML = JSON.stringify(status, null, 2);
-        const command = await control.getCommandById(status.command);
+        const command = await control.getCommandById(status['command@id']);
         commands.set(command.properties.id, command.properties);
         textCommandElt.innerHTML = "";
         commands.forEach(cmd => {

--- a/source/core/datasource/sweapi/handler/SweApiFetchHandler.js
+++ b/source/core/datasource/sweapi/handler/SweApiFetchHandler.js
@@ -48,9 +48,7 @@ class SensorWebApiFetchApiHandler  extends TimeSeriesDataSourceHandler {
 
                 let apiObject = new Control({
                     id: match[2],
-                    system: {
-                        id: match[1]
-                    }
+                    'system@id':match[1]
                 }, networkProperties);
 
                 if(stream) {

--- a/source/core/datasource/sweapi/worker/SweApiFetchJson.worker.js
+++ b/source/core/datasource/sweapi/worker/SweApiFetchJson.worker.js
@@ -1,5 +1,4 @@
 import SensorWebApiFetchHandler from "../handler/SweApiFetchHandler";
-import SweApiFetchStreamJsonParser from "../parser/json/SweApiFetchJson.parser";
 import SweApiFetchGenericJson from "../parser/json/SweApiFetchGenericJson.parser";
 
 let  dataSourceHandler = new SensorWebApiFetchHandler(new SweApiFetchGenericJson());

--- a/source/core/sweapi/command/Command.js
+++ b/source/core/sweapi/command/Command.js
@@ -39,8 +39,8 @@ class Command extends SensorWebApi {
      */
     async searchStatus(commandFilter = new CommandFilter(), pageSize= 10) {
         return new Collection(
-            API.commands.status.replace('{sysid}',this.properties.systemId)
-                               .replace('{dsid}', this.properties.commandstream)
+            API.commands.status.replace('{sysid}',this.properties['system@id'])
+                               .replace('{dsid}', this.properties['control@id'])
                                .replace('{cmdid}', this.properties.id),
             commandFilter, pageSize, this.jsonParser, this._network.info.connector);
     }
@@ -55,8 +55,8 @@ class Command extends SensorWebApi {
         this._network.stream.connector.onMessage = callback;
 
         this._network.stream.connector.doRequest(
-            API.commands.status.replace('{sysid}',this.properties.systemId)
-                .replace('{dsid}', this.properties.commandstream)
+            API.commands.status.replace('{sysid}',this.properties['system@id'])
+                .replace('{dsid}', this.properties['control@id'])
                 .replace('{cmdid}', this.properties.id),
             commandFilter.toQueryString(),
             'arraybuffer'

--- a/source/core/sweapi/control/Control.js
+++ b/source/core/sweapi/control/Control.js
@@ -29,7 +29,7 @@ class Control extends SensorWebApi {
     constructor(properties, networkProperties) {
         super(networkProperties); // network properties
         this.properties = properties;
-        this.commandParser = new SweApiFetchCommandParser(networkProperties, this.properties.system.id);
+        this.commandParser = new SweApiFetchCommandParser(networkProperties, this.properties['system@id']);
         this.jsonParser = new SweParser();
     }
 
@@ -41,7 +41,7 @@ class Control extends SensorWebApi {
      */
     async searchCommands(commandFilter = new CommandFilter(), pageSize= 10) {
         return new Collection(
-            API.controls.commands.replace('{sysid}',this.properties.system.id).replace('{dsid}',
+            API.controls.commands.replace('{sysid}',this.properties['system@id']).replace('{dsid}',
                 this.properties.id),commandFilter, pageSize,this.jsonParser, this._network.info.connector);
     }
 
@@ -60,7 +60,7 @@ class Control extends SensorWebApi {
         }
 
         this._network.stream.connector.doRequest(
-            API.controls.commands.replace('{sysid}',this.properties.system.id).replace('{dsid}',this.properties.id),
+            API.controls.commands.replace('{sysid}',this.properties['system@id']).replace('{dsid}',this.properties.id),
             controlFilter.toQueryString(),
             'arraybuffer'
         );
@@ -69,7 +69,7 @@ class Control extends SensorWebApi {
     async getCommandById(commandId,commandFilter = new CommandFilter()) {
         const response = await this._network.info.connector.doRequest(
             API.controls.command_by_id
-                .replace('{sysid}',this.properties.system.id)
+                .replace('{sysid}',this.properties['system@id'])
                 .replace('{dsid}', this.properties.id)
                 .replace('{cmdid}', commandId),
             commandFilter.toQueryString(['select','format']),
@@ -81,7 +81,7 @@ class Control extends SensorWebApi {
     postCommand(payload, commandFilter = new CommandFilter()) {
         this._network.info.connector.postRequest(
             API.controls.commands
-                .replace('{sysid}',this.properties.system.id)
+                .replace('{sysid}',this.properties['system@id'])
                 .replace('{dsid}', this.properties.id),
             payload,
             commandFilter.props.format
@@ -91,7 +91,7 @@ class Control extends SensorWebApi {
     publishCommand(payload, commandFilter = new CommandFilter()) {
         this._network.stream.connector.publishRequest(
             API.controls.commands
-                .replace('{sysid}',this.properties.system.id)
+                .replace('{sysid}',this.properties['system@id'])
                 .replace('{dsid}', this.properties.id),
             payload
         );
@@ -105,7 +105,7 @@ class Control extends SensorWebApi {
      */
     async searchStatus(controlFilter = new ControlFilter(), pageSize= 10) {
         return new Collection(
-            API.controls.status.replace('{sysid}',this.properties.system.id).replace('{dsid}',
+            API.controls.status.replace('{sysid}',this.properties['system@id']).replace('{dsid}',
                 this.properties.id),controlFilter, pageSize,this.jsonParser, this._network.info.connector);
     }
 
@@ -124,7 +124,7 @@ class Control extends SensorWebApi {
         }
 
         this._network.stream.connector.doRequest(
-            API.controls.status.replace('{sysid}',this.properties.system.id).replace('{dsid}',this.properties.id),
+            API.controls.status.replace('{sysid}',this.properties['system@id']).replace('{dsid}',this.properties.id),
             controlFilter.toQueryString(),
             'arraybuffer'
         );
@@ -137,7 +137,7 @@ class Control extends SensorWebApi {
      */
     async getSchema(controlFilter = new ControlFilter()) {
         return this._network.info.connector.doRequest(
-            API.controls.schema.replace('{sysid}',this.properties.system.id).replace('{dsid}',this.properties.id),
+            API.controls.schema.replace('{sysid}',this.properties['system@id']).replace('{dsid}',this.properties.id),
             controlFilter.toQueryString(['select', 'obsFormat']),
             controlFilter.props.format
         );


### PR DESCRIPTION
- Inside datastream resources, the system field becomes separate system@id and outputName fields
- Inside observation resources, the datastream field becomes datastream@id
- Inside control resources, system field becomes separate system@id and inputName fields
- Inside command resources, commandstream field becomes control@id
- Inside command status resources, command field becomes command@id
- Fix SweApi demo
- Fix Tasking demo
- Fix Tasking showcase example