### PR TITLE
Fix topic of MqttConnector

### DIFF
--- a/source/core/connector/MqttTopicConnector.js
+++ b/source/core/connector/MqttTopicConnector.js
@@ -28,10 +28,9 @@ class MqttTopicConnector extends DataConnector {
         this.broadcastChannel.postMessage({
             message: 'subscribe',
             connectorId: this.id,
-            topic: topic,
-            queryString: queryString
+            topic: this.fullTopic
         });
-        this.topics.push(topic);
+        this.topics.push(this.fullTopic);
         this.onChangeStatus(Status.CONNECTED);
     }
     /**

--- a/source/core/datasource/DataSource.datasource.js
+++ b/source/core/datasource/DataSource.datasource.js
@@ -31,26 +31,8 @@ const workersPool = [];
 let currentInsertPoolIdx = 0;
 let dataSourceWorkers={};
 
-let mqttConnectors = {};
-
 export function getDataSourceWorkers() {
     return dataSourceWorkers;
-}
-
-function createSharedMqttConnector(properties, topic) {
-    let endpoint = properties.mqttOpts.endpointUrl;
-
-    if (endpoint.endsWith('/')) {
-        endpoint = endpoint.substring(0, endpoint.length - 1);
-    }
-
-    const tls = (properties.tls) ? 's' : '';
-    const url =  'mqtt' + tls + '://' + endpoint;
-    if(!(url in mqttConnectors)) {
-        mqttConnectors[url] = new MqttConnector(url, properties);
-        mqttConnectors[url].initBc();
-    }
-    return mqttConnectors[url].id;
 }
 
 class DataSource {
@@ -64,10 +46,6 @@ class DataSource {
 
         if (isDefined(properties.mode)) {
             this.mode = properties.mode;
-        }
-
-        if(properties.protocol === 'mqtt') {
-            this.properties.mqttOpts.bcId = createSharedMqttConnector(properties);
         }
     }
 

--- a/source/core/datasource/TimeSeries.realtime.datasource.js
+++ b/source/core/datasource/TimeSeries.realtime.datasource.js
@@ -17,17 +17,42 @@
 import {DATA_SYNCHRONIZER_TOPIC, DATASOURCE_TIME_TOPIC} from "../Constants";
 import DataSource from "./DataSource.datasource";
 import {Mode} from './Mode';
+import MqttConnector from "../connector/MqttConnector";
 
 /**
  * The DataSource is the abstract class used to create different datasources.
  *
  */
+let mqttConnectors = {};
+
+function createSharedMqttConnector(properties, topic) {
+    let endpoint = properties.mqttOpts.endpointUrl;
+
+    if (endpoint.endsWith('/')) {
+        endpoint = endpoint.substring(0, endpoint.length - 1);
+    }
+
+    const tls = (properties.tls) ? 's' : '';
+    const url =  'mqtt' + tls + '://' + endpoint;
+    if(!(url in mqttConnectors)) {
+        mqttConnectors[url] = new MqttConnector(url, properties);
+        mqttConnectors[url].initBc();
+    } else {
+        console.log(`Reuse shared MqttConnector instance for ${url}`);
+    }
+    return mqttConnectors[url].id;
+}
+
 class TimeSeriesRealtimeDatasource extends DataSource {
     constructor(name, properties) {
         super(name, properties);
 
         this.dataSynchronizer = undefined;
         this.properties.version = 0;
+
+        if(properties.protocol === 'mqtt') {
+            this.properties.mqttOpts.bcId = createSharedMqttConnector(properties);
+        }
     }
 
     getTimeTopicId() {

--- a/source/core/mqtt/MqttProvider.js
+++ b/source/core/mqtt/MqttProvider.js
@@ -135,7 +135,7 @@ class MqttProvider {
      */
     async unsubscribe(topic) {
         const topicQuery = `${this.mqttPrefix}${topic}`;
-        return this.client.unsubscribe(topicQuery, err => {
+        return this.client.unsubscribe(topicQuery, {}, err => {
             delete mqttCallbacks[topicQuery];
             if (err) {
                 const messageErr = `Cannot Unsubscribed topic: ${topicQuery} : ${err}`;
@@ -175,10 +175,6 @@ class MqttProvider {
     }
 
     async onMessage(topic, message) {
-        // console.log(topic)
-        // console.log(new DataView(message.buffer, message.byteOffset).getFloat64(0, false) * 1000)
-        // console.log(new DataView(new Uint8Array(message).subarray(message.byteOffset).buffer).getFloat64(0, false) * 1000)
-        // console.log(String.fromCharCode.apply(null, new Uint8Array(message)));
         if (topic in mqttCallbacks) {
             // callback for the corresponding topic
             for (let callback of mqttCallbacks[topic]) {
@@ -201,6 +197,8 @@ class MqttProvider {
     isConnected() {
         return isDefined(this.client) && this.client.connected;
     }
+
+    reset() {}
 }
 
 export default MqttProvider;


### PR DESCRIPTION
Fix topic of MqttConnector which was composed of topic + '?' + queryString. After disconnecting, the queryString was not valid. It is better to compose the topic with the topic name associated with the queryString to avoid any misunderstanding which fixes the issue of stopping MQTT subscribe after unsubscribing a topic