### PR TITLE
Add support for String into BinaryDataParser

### DIFF
--- a/source/core/parsers/BinaryDataParser.js
+++ b/source/core/parsers/BinaryDataParser.js
@@ -15,6 +15,7 @@ import RootParser from "./common/RootParser";
 class BinaryDataParser extends GenericParser {
 
     constructor(rootElement, encoding, properties = {timeShift : 0}) {
+        console.log(encoding)
         super(rootElement, {
             nodesId: {},
             nodesIdValue: {},
@@ -46,6 +47,7 @@ class BinaryDataParser extends GenericParser {
         // parse schema
         this.props.registeredParser = {
             'Time': () => new BinaryTimeParser(),
+            'Text': () => new StringParser(),
             'Category': () => new StringParser(),
             'Quantity': () => new DecimalParser(),
             'Count': () => new CountParser(),

--- a/source/core/parsers/binary/ComponentParser.js
+++ b/source/core/parsers/binary/ComponentParser.js
@@ -3,6 +3,7 @@ import BinaryDoubleDataTypeDecoder from "./dataType/BinaryDoubleDataTypeDecoder"
 import BinaryIntegerDataTypeDecoder from "./dataType/BinaryIntegerDataTypeDecoder";
 import BinaryShortDataTypeDecoder from "./dataType/BinaryShortDataTypeDecoder";
 import BinaryFloat32DataTypeDecoder from "./dataType/BinaryFloat32DataTypeDecoder";
+import BinaryStringUtf8DataTypeDecoder from "./dataType/BinaryStringUtf8DataTypeDecoder";
 
 class ComponentParser extends AbstractParser {
     constructor(binaryDataTypeDecoder) {
@@ -20,6 +21,8 @@ class ComponentParser extends AbstractParser {
             this.refs[element.ref] = new BinaryShortDataTypeDecoder();
         } else if(element.dataType === 'http://www.opengis.net/def/dataType/OGC/0/float32') {
             this.refs[element.ref] = new BinaryFloat32DataTypeDecoder();
+        } else if(element.dataType === 'http://www.opengis.net/def/dataType/OGC/0/string-utf-8'){
+            this.refs[element.ref] = new BinaryStringUtf8DataTypeDecoder();
         }
         if(element.ref in this.refs) {
             this.binaryDataTypeDecoder.addRef(element.ref, this.refs[element.ref]);

--- a/source/core/parsers/binary/dataType/BinaryStringUtf8DataTypeDecoder.js
+++ b/source/core/parsers/binary/dataType/BinaryStringUtf8DataTypeDecoder.js
@@ -1,0 +1,28 @@
+// http://www.opengis.net/def/dataType/OGC/0/string-utf-8
+DataView.prototype.getString = function(offset, length,littleEndian){
+    let end = typeof length == 'number' ? offset + length : this.byteLength;
+    let text = '';
+    let val = -1;
+
+    while (offset < this.byteLength && offset < end){
+        val = this.getUint8(offset++, littleEndian);
+        if (val === 0) break;
+        text += String.fromCharCode(val);
+    }
+
+    return text;
+};
+
+const decoderForStringDataTypeDecoder = new TextDecoder("utf-8");
+
+class BinaryStringDataTypeDecoder {
+    decode(dataView, offset, littleEndian = false) {
+        this.strLength = dataView.getUint16(offset, littleEndian);
+        return decoderForStringDataTypeDecoder.decode(new DataView(dataView.buffer,offset+2, this.strLength));
+    }
+    length() {
+        // 2 = size of the strLength at the beginning of the string = getUint16()
+        return this.strLength+2;
+    }
+}
+export default BinaryStringDataTypeDecoder;


### PR DESCRIPTION
- Add support for http://www.opengis.net/def/dataType/OGC/0/string-utf-8 as DataType into BinaryDataParser
- Add support for Text type in common parser