### PR TITLE
Updated getValues Callback Function for CurveLayer

### DIFF
--- a/source/core/ui/layer/CurveLayer.js
+++ b/source/core/ui/layer/CurveLayer.js
@@ -122,8 +122,10 @@ class CurveLayer extends Layer {
         if (isDefined(properties.getValues)) {
             let fn = async (rec, timestamp, options) => {
                 const value = await that.getFunc('getValues')(rec,timestamp,options);
-                that.props.x = value.x;
-                that.props.y = value.y;
+                if (value != undefined || null) {
+                    that.props.x = value.x;
+                    that.props.y = value.y;
+                }
             };
             this.addFn(that.getDataSourcesIdsByProperty('getValues'), fn);
         }


### PR DESCRIPTION
Add if statement to getValues function allowing the handler to skip empty or null data from a data record without error when creating a visualization