### PR TITLE
Change ellipseID to ellipseId

### DIFF
--- a/source/core/ui/layer/EllipseLayer.js
+++ b/source/core/ui/layer/EllipseLayer.js
@@ -48,7 +48,7 @@ class EllipseLayer extends Layer {
      * @param {Function} [properties.getSemiMinorAxis] - defines a function to return the semiMinorAxis
      * @param {Function} [properties.getHeight] - defines a function to return the height of the ellipse above the ellipsoid
      * @param {Function} [properties.getRotation] - defines a function to return the rotation of the ellipse
-     * @param {Function} [properties.getEllipseId] - map an id to a unique ellipse
+     * @param {Function} [properties.getEllipseID] - map an id to a unique ellipse
      */
     constructor(properties) {
         super(properties);
@@ -98,7 +98,7 @@ class EllipseLayer extends Layer {
             props.zIndex = properties.zIndex;
         }
 
-        this.definedId('ellipseId', props)
+        this.definedId('ellipseID', props)
 
         if (isDefined(properties.getPosition)){
             let fn = async (rec, timestamp, options) => {

--- a/source/core/ui/layer/EllipseLayer.js
+++ b/source/core/ui/layer/EllipseLayer.js
@@ -48,7 +48,7 @@ class EllipseLayer extends Layer {
      * @param {Function} [properties.getSemiMinorAxis] - defines a function to return the semiMinorAxis
      * @param {Function} [properties.getHeight] - defines a function to return the height of the ellipse above the ellipsoid
      * @param {Function} [properties.getRotation] - defines a function to return the rotation of the ellipse
-     * @param {Function} [properties.getEllipseID] - map an id to a unique ellipse
+     * @param {Function} [properties.getEllipseId] - map an id to a unique ellipse
      */
     constructor(properties) {
         super(properties);
@@ -98,7 +98,7 @@ class EllipseLayer extends Layer {
             props.zIndex = properties.zIndex;
         }
 
-        this.definedId('ellipseID', props)
+        this.definedId('ellipseId', props)
 
         if (isDefined(properties.getPosition)){
             let fn = async (rec, timestamp, options) => {


### PR DESCRIPTION
This bug made open layers display one ellipse even if there are multiple in our datasources since it relies on the `ellipseId` field, not `ellipseID`, as a unique id to differentiate map features